### PR TITLE
Fix for underscores in model names

### DIFF
--- a/lib/model_to_locale/to_locale.rb
+++ b/lib/model_to_locale/to_locale.rb
@@ -8,7 +8,7 @@ class ToLocale
     data["#{locale}"]['activerecord']['attributes'] = Hash.new
 
     models.each do |model|
-      data["#{locale}"]['activerecord']['models']["#{model.downcase}"] = model.capitalize
+      data["#{locale}"]['activerecord']['models']["#{model.underscore}"] = model.capitalize
       data = add_attributes(data, model, locale)
     end
 
@@ -18,7 +18,7 @@ class ToLocale
   def self.add_model(model, locale='tr')
     begin
       data = YAML::load_file(Rails.root.join('config/locales', "models.#{locale}.yml"))
-      data["#{locale}"]['activerecord']['models']["#{model.downcase}"] = model.capitalize
+      data["#{locale}"]['activerecord']['models']["#{model.underscore}"] = model.capitalize
       data = add_attributes(data, model, locale)
       write_to_file(data, locale)
     rescue
@@ -37,9 +37,9 @@ class ToLocale
   def self.add_attributes(data, model, locale)
     begin
       columns = model.classify.constantize.column_names
-      data["#{locale}"]['activerecord']['attributes']["#{model.downcase}"] = Hash.new
+      data["#{locale}"]['activerecord']['attributes']["#{model.underscore}"] = Hash.new
       columns.each do |column|
-        data["#{locale}"]['activerecord']['attributes']["#{model.downcase}"]["#{column}"] = column.capitalize
+        data["#{locale}"]['activerecord']['attributes']["#{model.underscore}"]["#{column}"] = column.capitalize
       end
     rescue
       puts "Not found #{model} model."


### PR DESCRIPTION
I've tried to fix the problem of model names with two or more words.

Table with a name "daily_tasks" was occuring in the translation file as :dailytask. I think that should be :daily_task

Note: This is my first pull request for a public repository.
