### PR TITLE
gem was updated to Rails 5

### DIFF
--- a/lib/model_to_locale/to_locale.rb
+++ b/lib/model_to_locale/to_locale.rb
@@ -8,8 +8,10 @@ class ToLocale
     data["#{locale}"]['activerecord']['attributes'] = Hash.new
 
     models.each do |model|
-      data["#{locale}"]['activerecord']['models']["#{model.downcase}"] = model.capitalize
-      data = add_attributes(data, model, locale)
+      unless model == "SchemaMigration" || model == "ArInternalMetadatum"
+        data["#{locale}"]['activerecord']['models']["#{model.downcase}"] = model.capitalize
+        data = add_attributes(data, model, locale)
+      end
     end
 
     write_to_file(data, locale)


### PR DESCRIPTION
SchemaMigration and ArInternalMetadatum models which are not exist in Rails 4 are coming with Rails 5 therefore this gem was edited to pass the SchemaMigration and ArInternalMetadatum Models.
